### PR TITLE
Update mailing list section with link to Discourse

### DIFF
--- a/docs/sections/mailing_list.md
+++ b/docs/sections/mailing_list.md
@@ -1,8 +1,20 @@
-# Mailing list
+# Discourse
+
+The main communication platform for AiiDA is the [Discourse server](https://aiida.discourse.group).
+It is mostly designed to be used as a traditional discussion forum, but it can also be used to function as a mailing list.
+See [this post](https://discourse.mozilla.org/t/how-do-i-use-discourse-via-email/15279) for details on how to configure it as such.
+
+
+# Legacy Google group
+
+Below is the information of the legacy Google mailing list that was active until September 2023.
+It has since been replaced by a [Discourse server](https://aiida.discourse.group).
+
+## Mailing list
 
 AiiDA provides a [fully archived](https://groups.google.com/forum/?hl=en#!forum/aiidausers) mailing list for general announcements and questions related to AiiDA. Only subscribed users can post new topics.
 
-## How to subscribe
+### How to subscribe
 
 To subscribe
 
@@ -16,7 +28,7 @@ Using the forum interface on groups.google.com requires a Google account. If you
 
 In case you encounter problems, please contact [developers@aiida.net](mailto:developers@aiida.net)  with your name, institution and the email you would like to use.
 
-## Posting Guidelines
+### Posting Guidelines
 
 Start a new discussion topic by sending an email to [aiidausers@googlegroups.com](mailto:aiidausers@googlegroups.com)
 
@@ -27,6 +39,6 @@ Start a new discussion topic by sending an email to [aiidausers@googlegroups.com
 
 This mailing list is maintained by volunteers, so please allow for adequate time for receiving a response.
 
-## How to unsubscribe
+### How to unsubscribe
 
 Simply send an email to [aiidausers+](mailto:aiidausers+subscribe@googlegroups.com)[un](mailto:aiidausers+subscribe@googlegroups.com)[subscribe@googlegroups.com](mailto:aiidausers+subscribe@googlegroups.com).


### PR DESCRIPTION
The information on the Google mailing list is kept for the time being for reference but may be removed at a later point in time.