### PR TITLE
Change title of the page with info on mailing list

### DIFF
--- a/docs/sections/mailing_list.md
+++ b/docs/sections/mailing_list.md
@@ -1,7 +1,7 @@
-# Discourse
+# Support
 
-The main communication platform for AiiDA is the [Discourse server](https://aiida.discourse.group).
-It is mostly designed to be used as a traditional discussion forum, but it can also be used to function as a mailing list.
+If you require support, or want to discuss anything surrounding AiiDA and its use, please feel free to post on the [Discourse server](https://aiida.discourse.group).
+The Discourse platform is mostly designed to be used as a traditional discussion forum, but it can also be used to function as a mailing list.
 See [this post](https://discourse.mozilla.org/t/how-do-i-use-discourse-via-email/15279) for details on how to configure it as such.
 
 


### PR DESCRIPTION
The header is used as title in the drop down.
"Discourse" is not intuitive for users looking for support so the header is changed to "Support".