### PR TITLE
Add blog posts

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The top-matter `category` should be one of the following:
 - `Events`: To announce an event
 - `Reports`: To report on an event
 - `Release`: To announce a new release
+- `Blog`: A blog post
 
 You can use the [update](https://ablog.readthedocs.io/en/latest/manual/posting-and-listing/#directive-update) directive to note an update to an existing post.
 

--- a/docs/extensions/check_events.py
+++ b/docs/extensions/check_events.py
@@ -25,7 +25,9 @@ def check_events(app: Sphinx, env: BuildEnvironment):
             if post["docname"] in env.config.aiida_ignore_event_checks:
                 continue
             category: set[str] = post["category"]
-            if not category.intersection(("Reports", "News", "Events", "Releases")):
+            if not category.intersection(
+                ("Reports", "News", "Events", "Releases", "Blog")
+            ):
                 LOGGER.warning(
                     f"Post does not have a valid category [aiida]",
                     location=post["docname"],

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,13 +4,12 @@ html_theme.sidebar_secondary.remove: true
 
 ```{toctree}
 :hidden:
-Home <self>
 Download <sections/download.md>
 Docs <https://aiida-core.readthedocs.io>
 Support <sections/mailing_list.md>
 Plugins <https://aiidateam.github.io/aiida-registry>
+Posts <news/index.md>
 About <sections/about.md>
-News <news/index.md>
 Tutorials <https://aiida-tutorials.readthedocs.io>
 sections/team.md
 sections/events.md
@@ -118,7 +117,7 @@ Open Source
 ::::{div} section-flex alternate-bg
 :::{div} section-contents
 
-<h2 class="front">Latest News
+<h2 class="front">Latest posts
 <a class="headerlink" href="#latest-news" title="Permalink to this heading">#</a>
 </h2>
 


### PR DESCRIPTION
This is an alternative for the [`aiida-blog`](https://github.com/aiidateam/aiida-blog/) repository. Instead of using a separate stand-alone repo, why not incorporate these blog posts in the AiiDA website. The current setup already _is_ a blog under the hood, it is currently just being used for all the news, release and events posts. Here we just add the `Blog` category.