### PR TITLE
Upgrade to sphinx 8

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,6 +17,7 @@ extensions = [
     "legacy_redirects",
     "check_events",
     "selective_css",
+    "sphinx_favicon",
 ]
 
 # see https://myst-parser.readthedocs.io
@@ -29,6 +30,12 @@ html_css_files = ["custom.css"]
 templates_path = ["_templates"]
 html_show_sourcelink = False
 
+# sphinx_favicon
+favicons = [
+    "favicon-16x16.png",
+    "favicon-32x32.png",
+]
+
 # see https://pydata-sphinx-theme.readthedocs.io
 html_theme_options = {
     # "announcement": "Welcome to the new AiiDA site!",
@@ -36,18 +43,6 @@ html_theme_options = {
         "image_light": "logo-light.svg",
         "image_dark": "logo-dark.svg",
     },
-    "favicons": [
-        {
-            "rel": "icon",
-            "sizes": "16x16",
-            "href": "favicon-16x16.png",
-        },
-        {
-            "rel": "icon",
-            "sizes": "32x32",
-            "href": "favicon-32x32.png",
-        },
-    ],
     "icon_links": [
         {
             "name": "Discourse",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -69,7 +69,7 @@ html_theme_options = {
         "theme-switcher",
         "navbar-icon-links",
     ],
-    "footer_items": ["copyright"],
+    "footer_start": ["copyright"],
     "use_edit_page_button": True,
     "search_bar_text": "Search ...",
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ sphinx-design~=0.6.1
 sphinx_subfigure~=0.2.4
 sphinx-notfound-page~=1.0.4
 sphinx-timeline~=0.2.1
+sphinx_favicon~=1.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
-myst-parser~=0.18.0
-pydata-sphinx-theme==0.15.2
+sphinx~=8.0.0
+myst-parser~=4.0.0
+pydata-sphinx-theme~=0.15.4
 ablog~=0.10.25
-sphinx-design~=0.3.0
+sphinx-design~=0.6.1
 sphinx_subfigure~=0.2.4
-sphinx-notfound-page~=0.8.3
+sphinx-notfound-page~=1.0.4
 sphinx-timeline~=0.2.1


### PR DESCRIPTION
I wanted to use `linkcheck_anchors_ignore_for_url` which is available sphinx>=0.7.1. I thought I just update directly to sphinx 8.