### PR TITLE
Devops: Add explicit `sphinx.configuration` key to RTD conf 

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,4 +11,5 @@ python:
 
 sphinx:
   builder: html
+  configuration: docs/source/conf.py
   fail_on_warning: true

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,5 +11,5 @@ python:
 
 sphinx:
   builder: html
-  configuration: docs/source/conf.py
+  configuration: docs/conf.py
   fail_on_warning: true


### PR DESCRIPTION
see https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/