### PR TITLE
Brilliant frontpage: hero, demo, provenance and visual polish

### DIFF
--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -264,7 +264,7 @@ const componentExplanations: Record<string, string> = {
   WorkChain: 'Orchestrates multi-step workflows with checkpoints. Survives restarts — picks up exactly where it left off.',
   CalcJob: 'Wraps a single computation on a remote machine. Handles file staging, submission, and retrieval automatically.',
   Parser: 'Extracts structured data from raw calculation outputs into queryable AiiDA nodes.',
-  Function: 'Lightweight Python function decorated as a workflow step. No remote submission — runs locally.',
+  Function: 'Python helper that submits a CalcJob under the hood.',
 };
 
 const plugins = [

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -2217,7 +2217,7 @@ function HighThroughputCombined(): ReactNode {
           <span className="hero-accent hero-accent--blue">A</span>utomated{' '}
           <span className="hero-accent hero-accent--green">I</span>nteractive{' '}
           <span className="hero-accent hero-accent--green">I</span>nfrastructure and{' '}
-          <span className="hero-accent hero-accent--orange">D</span><span className="hero-accent hero-accent--blue">A</span>tabase
+          <span className="hero-accent hero-accent--orange">D</span><span className="hero-accent hero-accent--orange">A</span>tabase
           <br />
           for Computational Science
         </p>

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -4026,7 +4026,6 @@ function InteractiveTutorial({ onPhaseChange, renderLayout }: { onPhaseChange?: 
                 {'\u2713'} One-time setup complete!
               </p>
             )}
-            <h3 className="tut-step-title">{s.title}</h3>
             <p className="tut-step-desc">{s.desc}</p>
           </div>
           <div className="tut-nav">

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -3961,7 +3961,7 @@ function InteractiveTutorial({ onPhaseChange, renderLayout }: { onPhaseChange?: 
             </div>
           ))}
           <div className="verdi-console-input-row" style={inputRowHidden ? {display: 'none'} : undefined}>
-            <span className="verdi-console-prompt" style={promptMode ? {color: '#f9e2af'} : undefined}>
+            <span className="verdi-console-prompt" style={promptMode ? {color: 'var(--screen-prompt-interactive)'} : undefined}>
               {promptMode ? `${promptMode.prompts[promptMode.current].label}: ` : '$ '}
             </span>
             <input

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -22,7 +22,7 @@ const base = import.meta.env.BASE_URL?.replace(/\/$/, '') || '';
     <meta name="description" content={description} />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet" />
     <script is:inline>
       (function(){var t=localStorage.getItem('theme');if(t==='dark'||(!t&&matchMedia('(prefers-color-scheme:dark)').matches))document.documentElement.setAttribute('data-theme','dark');else document.documentElement.setAttribute('data-theme','light')})();
     </script>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -35,9 +35,22 @@ html {
   --ifm-color-emphasis-300: var(--color-border);
   --ifm-background-surface-color: var(--color-bg-surface);
   --ifm-font-color-base: var(--color-text);
-  --device-bg: #e4e6ec;
-  --device-border: #c0c4d0;
-  --device-screen-bg: #1e1e2e;
+  /* Device chrome (laptop frame, server rack) — physically dark; sky-blue tint in day mode */
+  --device-bg: #3e4a7a;
+  --device-border: #525e91;
+  /* Screen surfaces (laptop screen, scheduler cards, terminal) — follow page theme */
+  --device-screen-bg: var(--color-bg-alt);
+  --device-screen-text: var(--color-text);
+  --screen-bg: var(--color-bg-alt);
+  --screen-bg-alt: var(--color-bg-surface);
+  --screen-text: var(--color-text);
+  --screen-text-muted: var(--color-text-muted);
+  --screen-border: var(--color-border-light);
+  --screen-prompt: var(--color-accent-green);
+  --screen-tab-active-bg: var(--color-bg);
+  --screen-tab-active-border: var(--color-border);
+  --screen-tab-hover-color: var(--color-text-secondary);
+  --screen-scrollbar-thumb: var(--color-border);
   /* Design system — all three AiiDA brand colors */
   --color-accent-orange: #e06800;
   --color-accent-green: #28a006;
@@ -65,9 +78,8 @@ html {
   --color-primary-light: #38b4f0;
   --color-primary-lighter: #5cc3f5;
   --color-primary-lightest: #7dd1f8;
-  --device-bg: #121420;
-  --device-border: #252840;
-  --device-screen-bg: #1e1e2e;
+  --device-bg: #2e3440;
+  --device-border: #434c5e;
   --color-accent-orange: #ff7d17;
   --color-accent-green: #30b808;
   --color-bg-tinted: #121428;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -47,6 +47,7 @@ html {
   --screen-text-muted: var(--color-text-muted);
   --screen-border: var(--color-border-light);
   --screen-prompt: var(--color-accent-green);
+  --screen-prompt-interactive: #a65b00;
   --screen-tab-active-bg: var(--color-bg);
   --screen-tab-active-border: var(--color-border);
   --screen-tab-hover-color: var(--color-text-secondary);
@@ -91,6 +92,7 @@ html {
   --color-border-accent-orange: rgba(255, 125, 23, 0.12);
   --color-shadow-accent: rgba(0, 150, 222, 0.08);
   --color-heading-accent: #4ab8f0;
+  --screen-prompt-interactive: #f9e2af;
   color-scheme: dark;
 }
 

--- a/src/styles/landing.css
+++ b/src/styles/landing.css
@@ -1065,7 +1065,7 @@ main > section > h2::after {
   border-bottom: 1px solid transparent;
   margin-bottom: -1px;
   font-family: var(--font-base);
-  font-size: 0.72rem;
+  font-size: 0.8rem;
   font-weight: 400;
   color: var(--color-text-muted);
   text-align: left;
@@ -1129,13 +1129,6 @@ main > section > h2::after {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-}
-
-.tut-step-title {
-  font-size: clamp(0.9rem, 1.2vw, 1.15rem);
-  font-weight: 700;
-  color: var(--color-text);
-  margin: 0;
 }
 
 .tut-step-desc {

--- a/src/styles/landing.css
+++ b/src/styles/landing.css
@@ -995,6 +995,7 @@ main > section > h2::after {
   flex-direction: column;
   cursor: text;
   min-width: 0;
+  font-family: var(--font-mono);
 }
 
 .tut-terminal-scroll {
@@ -1342,6 +1343,12 @@ main > section > h2::after {
   caret-color: var(--screen-prompt);
   padding: 0;
   margin: 0 0 0 clamp(2px, 0.35vw, 4px);
+}
+
+.verdi-console-input::placeholder {
+  font-family: var(--font-mono);
+  color: var(--screen-text-muted);
+  opacity: 0.8;
 }
 
 /* Stream lines */

--- a/src/styles/landing.css
+++ b/src/styles/landing.css
@@ -218,7 +218,7 @@ main > section > h2::after {
 .server-label {
   font-family: var(--font-base);
   font-size: clamp(8px, 0.95vw, 11px);
-  fill: #cdd6f4;
+  fill: var(--device-screen-text);
   font-weight: 500;
 }
 
@@ -987,7 +987,7 @@ main > section > h2::after {
 /* Terminal panel — hosts the live console and the file tabs */
 .tut-terminal {
   flex: 1;
-  background: #1e1e2e;
+  background: var(--screen-bg);
   border-radius: 10px;
   outline: none;
   overflow: hidden;
@@ -1009,7 +1009,7 @@ main > section > h2::after {
   font-size: clamp(9px, 1.1vw, 13px);
   line-height: 1.6;
   scrollbar-width: thin;
-  scrollbar-color: #45475a #1e1e2e;
+  scrollbar-color: var(--screen-scrollbar-thumb) var(--screen-bg);
 }
 
 .tut-terminal-scroll .verdi-console-input-row {
@@ -1021,7 +1021,7 @@ main > section > h2::after {
   flex: 1;
   margin: 0;
   padding: clamp(8px, 1.3vw, 16px);
-  color: #cdd6f4;
+  color: var(--screen-text);
   font-family: var(--font-mono);
   font-size: clamp(9px, 1.05vw, 12.5px);
   line-height: 1.65;
@@ -1031,7 +1031,7 @@ main > section > h2::after {
   overscroll-behavior: contain;
   max-height: 460px;
   scrollbar-width: thin;
-  scrollbar-color: #45475a #1e1e2e;
+  scrollbar-color: var(--screen-scrollbar-thumb) var(--screen-bg);
 }
 
 /* Instructions panel (right) */
@@ -1209,7 +1209,7 @@ main > section > h2::after {
 
 /* === Interactive Verdi Terminal === */
 .verdi-console {
-  background: #1e1e2e;
+  background: var(--screen-bg);
   border-radius: 12px;
   overflow: hidden;
   max-width: 960px;
@@ -1221,7 +1221,7 @@ main > section > h2::after {
 }
 
 .verdi-console-titlebar {
-  background: #181825;
+  background: var(--screen-bg-alt);
   padding: clamp(5px, 0.85vw, 10px) clamp(8px, 1.3vw, 16px);
   display: flex;
   align-items: center;
@@ -1255,7 +1255,7 @@ main > section > h2::after {
 .tut-tab {
   font-family: var(--font-mono);
   font-size: clamp(9px, 1vw, 12px);
-  color: #6c7086;
+  color: var(--screen-text-muted);
   background: transparent;
   border: 1px solid transparent;
   padding: clamp(2px, 0.35vw, 4px) clamp(6px, 1vw, 12px);
@@ -1272,13 +1272,13 @@ main > section > h2::after {
 }
 
 .tut-tab:hover {
-  color: #a6adc8;
+  color: var(--screen-tab-hover-color);
 }
 
 .tut-tab.active {
-  color: #cdd6f4;
-  background: #1e1e2e;
-  border-color: #313244;
+  color: var(--screen-text);
+  background: var(--screen-tab-active-bg);
+  border-color: var(--screen-tab-active-border);
 }
 
 .verdi-console-output {
@@ -1290,7 +1290,7 @@ main > section > h2::after {
   font-size: clamp(10px, 1.15vw, 14px);
   line-height: 1.6;
   scrollbar-width: thin;
-  scrollbar-color: #45475a #1e1e2e;
+  scrollbar-color: var(--screen-scrollbar-thumb) var(--screen-bg);
 }
 
 .verdi-console-output::-webkit-scrollbar {
@@ -1298,21 +1298,21 @@ main > section > h2::after {
 }
 
 .verdi-console-output::-webkit-scrollbar-track {
-  background: #1e1e2e;
+  background: var(--screen-bg);
 }
 
 .verdi-console-output::-webkit-scrollbar-thumb {
-  background: #45475a;
+  background: var(--screen-scrollbar-thumb);
   border-radius: 3px;
 }
 
 .verdi-line-cmd {
-  color: #a6e3a1;
+  color: var(--screen-prompt);
   white-space: pre;
 }
 
 .verdi-line-out {
-  color: #cdd6f4;
+  color: var(--screen-text);
   white-space: pre;
   opacity: 0.9;
 }
@@ -1326,7 +1326,7 @@ main > section > h2::after {
 }
 
 .verdi-console-prompt {
-  color: #a6e3a1;
+  color: var(--screen-prompt);
   user-select: none;
   flex-shrink: 0;
 }
@@ -1334,12 +1334,12 @@ main > section > h2::after {
 .verdi-console-input {
   background: transparent;
   border: none;
-  color: #a6e3a1;
+  color: var(--screen-prompt);
   font-family: var(--font-mono);
   font-size: clamp(10px, 1.15vw, 14px);
   outline: none;
   flex: 1;
-  caret-color: #a6e3a1;
+  caret-color: var(--screen-prompt);
   padding: 0;
   margin: 0 0 0 clamp(2px, 0.35vw, 4px);
 }
@@ -2747,23 +2747,23 @@ main > section > h2::after {
 
 /* --- Terminal window chrome --- */
 .terminal-proto-window {
-  background: #1a1b2e;
+  background: var(--screen-bg);
   border-radius: clamp(6px, 1vw, 12px);
   overflow: hidden;
   box-shadow:
     0 8px 32px rgba(0, 0, 0, 0.28),
     0 2px 8px rgba(0, 0, 0, 0.12);
-  border: 1px solid rgba(255, 255, 255, 0.06);
+  border: 1px solid var(--screen-border);
 }
 
 .terminal-proto-titlebar {
-  background: #14152a;
+  background: var(--screen-bg-alt);
   padding: clamp(5px, 0.9vw, 11px) clamp(8px, 1.3vw, 16px);
   display: flex;
   align-items: center;
   gap: clamp(4px, 0.7vw, 8px);
   user-select: none;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+  border-bottom: 1px solid var(--screen-border);
 }
 
 .terminal-proto-dot {
@@ -2788,7 +2788,7 @@ main > section > h2::after {
   text-align: center;
   font-size: clamp(9px, 1vw, 12px);
   font-family: var(--font-mono);
-  color: #6c7086;
+  color: var(--screen-text-muted);
   letter-spacing: 0.02em;
 }
 
@@ -2804,46 +2804,46 @@ main > section > h2::after {
   font-family: var(--font-mono);
   font-size: clamp(9px, 1.1vw, 13px);
   line-height: 1.7;
-  color: #cdd6f4;
+  color: var(--screen-text);
   overflow-x: auto;
 }
 
 .terminal-proto-panel--left {
-  border-right: 1px solid rgba(255, 255, 255, 0.06);
+  border-right: 1px solid var(--screen-border);
 }
 
 /* --- Prompt and output styling --- */
 .terminal-proto-prompt {
-  color: #a6e3a1;
+  color: var(--screen-prompt);
   white-space: pre;
   display: block;
   margin-bottom: 4px;
 }
 
 .terminal-proto-output {
-  color: #bac2de;
+  color: var(--screen-text);
   white-space: pre;
   display: block;
 }
 
 .terminal-proto-label {
-  color: #6c7086;
+  color: var(--screen-text-muted);
 }
 
 .terminal-proto-value {
-  color: #cdd6f4;
+  color: var(--screen-text);
 }
 
 .terminal-proto-value--highlight {
-  color: #a6e3a1;
+  color: var(--screen-prompt);
 }
 
 .terminal-proto-pid {
-  color: #89b4fa;
+  color: var(--color-primary);
 }
 
 .terminal-proto-since {
-  color: #6c7086;
+  color: var(--screen-text-muted);
 }
 
 /* --- Process table --- */
@@ -2860,9 +2860,9 @@ main > section > h2::after {
   display: flex;
   gap: 0;
   padding: 0 0 clamp(3px, 0.5vw, 6px);
-  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  border-bottom: 1px solid var(--screen-border);
   margin-bottom: 2px;
-  color: #6c7086;
+  color: var(--screen-text-muted);
   font-size: clamp(8px, 0.95vw, 11.5px);
   font-weight: 600;
   letter-spacing: 0.03em;
@@ -2870,7 +2870,7 @@ main > section > h2::after {
 
 .terminal-proto-table-divider {
   display: block;
-  color: #45475a;
+  color: var(--screen-scrollbar-thumb);
   font-size: 11.5px;
   padding: 2px 0;
   user-select: none;
@@ -2903,19 +2903,19 @@ main > section > h2::after {
   flex-shrink: 0;
   text-align: right;
   padding-right: clamp(5px, 0.85vw, 10px);
-  color: #89b4fa;
+  color: var(--color-primary);
 }
 
 .terminal-proto-col-created {
   width: clamp(50px, 6vw, 72px);
   flex-shrink: 0;
-  color: #6c7086;
+  color: var(--screen-text-muted);
 }
 
 .terminal-proto-col-process {
   width: clamp(70px, 9vw, 108px);
   flex-shrink: 0;
-  color: #cdd6f4;
+  color: var(--screen-text);
 }
 
 .terminal-proto-col-state {
@@ -2926,7 +2926,7 @@ main > section > h2::after {
 .terminal-proto-col-computer {
   flex: 1;
   min-width: 0;
-  color: #a6adc8;
+  color: var(--screen-text);
 }
 
 /* --- State badges --- */
@@ -2939,7 +2939,7 @@ main > section > h2::after {
 }
 
 .terminal-proto-state--created {
-  color: #6c7086;
+  color: var(--screen-text-muted);
 }
 
 .terminal-proto-state--running {
@@ -2967,7 +2967,7 @@ main > section > h2::after {
 
 /* Watch header */
 .terminal-proto-watch-header {
-  color: #6c7086;
+  color: var(--screen-text-muted);
   font-size: 10px;
   margin: 4px 0 8px;
   font-family: var(--font-mono);
@@ -3563,15 +3563,14 @@ main > section > h2::after {
   width: clamp(3px, 0.5vw, 6px);
   height: clamp(3px, 0.5vw, 6px);
   border-radius: 50%;
-  background: var(--device-border);
+  background: rgba(0, 0, 0, 0.75);
   margin: 0 auto clamp(2px, 0.4vw, 5px);
-  opacity: 0.5;
 }
 
 .tp-laptop-screen {
   display: flex;
   gap: 1px;
-  background: #15161e;
+  background: var(--screen-bg-alt);
   border-radius: clamp(2px, 0.35vw, 4px);
   overflow: hidden;
   aspect-ratio: 16 / 10;
@@ -3590,7 +3589,7 @@ main > section > h2::after {
   flex: 1;
   display: flex;
   flex-direction: column;
-  background: #1e1e2e;
+  background: var(--screen-bg);
   min-width: 0;
   overflow: hidden;
 }
@@ -3600,15 +3599,15 @@ main > section > h2::after {
   align-items: center;
   gap: clamp(3px, 0.5vw, 6px);
   padding: clamp(4px, 0.6vw, 7px) clamp(6px, 1vw, 12px);
-  background: #181825;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  background: var(--screen-bg-alt);
+  border-bottom: 1px solid var(--screen-border);
   flex-shrink: 0;
 }
 
 .tp-panel-title {
   font-family: var(--font-mono);
   font-size: clamp(8px, 0.95vw, 11px);
-  color: #6c7086;
+  color: var(--screen-text-muted);
   margin-left: clamp(2px, 0.35vw, 4px);
 }
 
@@ -3616,7 +3615,7 @@ main > section > h2::after {
   padding: clamp(6px, 1vw, 12px) clamp(8px, 1.3vw, 16px);
   font-family: var(--font-mono);
   font-size: clamp(9px, 1vw, 12px);
-  color: #cdd6f4;
+  color: var(--screen-text);
   overflow-y: auto;
   flex: 1;
 }

--- a/src/styles/landing.css
+++ b/src/styles/landing.css
@@ -53,7 +53,7 @@ main > section > h2::after {
 .hero-header {
   position: relative;
   z-index: 1;
-  padding: 2.4rem 0 2.5rem;
+  padding: 5rem 0 2.5rem;
   margin-bottom: 2rem;
   text-align: center;
 }
@@ -67,7 +67,7 @@ main > section > h2::after {
 }
 
 .hero-brand-logo {
-  height: clamp(60px, 10vw, 100px);
+  height: clamp(60px, 10vw, 125px);
   width: auto;
 }
 
@@ -135,9 +135,9 @@ main > section > h2::after {
 }
 
 .hero-subtitle {
-  font-size: clamp(0.95rem, 1.8vw, 1.2rem);
+  font-size: clamp(0.95rem, 1.8vw, 1.5rem);
   color: var(--color-text-secondary);
-  max-width: 700px;
+  max-width: 800px;
   margin: 0 auto 0.5rem;
   line-height: 1.6;
 }


### PR DESCRIPTION
- Bigger hero header, logo, subtitle; orange "DA" in DAtabase
- Demo terminal in JetBrains Mono; tab header polish; drop duplicate step title
- Laptop + scheduler cards themed via CSS vars (light/dark)
- Fix aiida-shell Function category description
