### PR TITLE
Auto-close PRs from forks

### DIFF
--- a/.github/workflows/close-fork-prs.yml
+++ b/.github/workflows/close-fork-prs.yml
@@ -1,6 +1,5 @@
 name: Close fork PRs
 
-
 on:
   pull_request_target:
     types:

--- a/.github/workflows/close-fork-prs.yml
+++ b/.github/workflows/close-fork-prs.yml
@@ -1,16 +1,5 @@
 name: Close fork PRs
 
-# This project's contribution policy asks the community to open issues rather
-# than PRs — the maintainers handle implementation. Fork PRs also can't get a
-# Cloudflare Pages preview deployment (CF skips them for security reasons), so
-# they'd be hard to review even if welcomed. This workflow detects fork PRs at
-# open time and closes them with a comment redirecting the contributor to
-# Issues. See README.md for the full policy.
-#
-# Uses `pull_request_target` so the action has write permission even on fork
-# PRs. Only event metadata (head/base repo names) is consulted — the PR's code
-# is never checked out, which is the security recommendation for any
-# `pull_request_target` workflow.
 
 on:
   pull_request_target:

--- a/.github/workflows/close-fork-prs.yml
+++ b/.github/workflows/close-fork-prs.yml
@@ -1,0 +1,53 @@
+name: Close fork PRs
+
+# This project's contribution policy asks the community to open issues rather
+# than PRs — the maintainers handle implementation. Fork PRs also can't get a
+# Cloudflare Pages preview deployment (CF skips them for security reasons), so
+# they'd be hard to review even if welcomed. This workflow detects fork PRs at
+# open time and closes them with a comment redirecting the contributor to
+# Issues. See README.md for the full policy.
+#
+# Uses `pull_request_target` so the action has write permission even on fork
+# PRs. Only event metadata (head/base repo names) is consulted — the PR's code
+# is never checked out, which is the security recommendation for any
+# `pull_request_target` workflow.
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+
+permissions:
+  pull-requests: write
+
+jobs:
+  close-fork-pr:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name != github.repository
+    steps:
+      - name: Comment and close
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const issuesUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/issues/new`;
+            const body = [
+              `Hi @${pr.user.login}, thank you so much for taking the time to propose this change — we really appreciate the gesture! 🙏`,
+              ``,
+              `A small note on how we work here: this site is maintained directly by the AiiDA team, and we kindly ask the community to share suggestions via **[issues](${issuesUrl})** rather than pull requests. Whatever the change — a typo, a broken link, outdated content, a content tweak, a bigger design idea — please describe it in an issue and we'll take it from there. The "Contributing" section of the README explains the why.`,
+              ``,
+              `Closing this PR for now. Your commits are still on \`${pr.head.repo.full_name}:${pr.head.ref}\` if you'd like to link to them from an issue.`,
+            ].join("\n");
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              body,
+            });
+            await github.rest.pulls.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              state: "closed",
+            });

--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ npm run preview
 
 The site is deployed to Cloudflare Pages.
 
+## Contributing
+
+Thanks for your interest in helping! This site is maintained directly by the AiiDA team, and we kindly ask the community to share feedback through [**issues**](https://github.com/aiidateam/aiida-website/issues/new) rather than pull requests. Whether it's a typo, a broken link, outdated content, or a content suggestion — please open an issue and we'll take care of the implementation. To keep the workflow consistent, PRs opened from forks are gently auto-closed with a comment pointing back here.
+
+Two reasons behind the policy: (1) the site benefits from a single editorial voice, so changes flow through the team rather than landing piecemeal; and (2) Cloudflare Pages doesn't build preview deployments for fork PRs (a security default — the build environment can hold project secrets), so a fork PR can't be reviewed visually anyway. Routing through issues keeps the loop short for everyone.
+
 ## How to cite AiiDA
 
 If AiiDA helped your research, please cite the relevant papers below.


### PR DESCRIPTION
Cloudflare Pages doesn't build preview deployments for fork PRs (its build env can hold project secrets, so untrusted code is hard-refused — see CF docs). The Read-the-Docs-style "previews on forks" we used to have only worked because RTD's build had no secrets to protect. Restoring fork previews on CF would mean a two-stage GitHub Actions workflow (build artifact in untrusted context → deploy via CF API token in trusted context), which is real CI surface to maintain for a project that is mostly maintainer-driven. Auto-closing fork PRs with a clear comment is the lower-cost path; we can revisit if community contributions pick up. 

Note: opening PRs on this repo from the community is discouraged anyways, we recommend that they open issues, and leave the implementation to us. 