### PR TITLE
fix(links): BASE_URL joins

### DIFF
--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -15,12 +15,14 @@ const { post } = Astro.props;
 const { Content } = await render(post);
 const date = post.data.date;
 const dateStr = date.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
+
+const base = import.meta.env.BASE_URL?.replace(/\/$/, '') || '';
 ---
 
 <Layout title={`${post.data.title} — AiiDA Blog`}>
   <main class="blog-post-page">
     <article class="blog-post">
-      <a href={`${import.meta.env.BASE_URL}/blog/`} class="blog-back">&larr; All posts</a>
+      <a href={`${base}/blog/`} class="blog-back">&larr; All posts</a>
       <header class="blog-post-header">
         <div class="blog-post-meta">
           <time datetime={date.toISOString().slice(0,10)}>{dateStr}</time>

--- a/src/pages/team.astro
+++ b/src/pages/team.astro
@@ -111,7 +111,7 @@ const formerMembers = [
 
     <div class="contact-section">
       <h2>Join us</h2>
-      <p>Interested in the intersection of software and computational science? We advertise openings on <a href="https://aiida.discourse.group/c/announcements/">Discourse</a> and the <a href={`${import.meta.env.BASE_URL}/blog/`}>News section</a>. Excellent candidates are encouraged to apply throughout the year.</p>
+      <p>Interested in the intersection of software and computational science? We advertise openings on <a href="https://aiida.discourse.group/c/announcements/">Discourse</a> and the <a href={`${base}/blog/`}>News section</a>. Excellent candidates are encouraged to apply throughout the year.</p>
       <p>Check open positions on the <a href="https://www.psi.ch/en/hr/job-opportunities">PSI website</a>, <a href="https://theos-wiki.epfl.ch/">THEOS</a>, and the <a href="https://psi-k.net">psi-k</a> mailing list.</p>
     </div>
   </main>


### PR DESCRIPTION
Two links on the live site point at `//blog/`, which browsers read as a host named `blog`, so clicking either one lands on a DNS error instead of the news listing. Broken since the Astro rewrite, reproducible in production right now:

- open any post from [aiida.net/blog/](https://aiida.net/blog/) and click "← All posts" at the top of the article
- on [aiida.net/team/](https://aiida.net/team/), scroll to "Join us" and click "News section"

Both come from a URL join that skips the trailing-slash guard the rest of the codebase uses:

- `base: "/"` means `import.meta.env.BASE_URL` is already `"/"`, so `${BASE_URL}/blog/` yields `//blog/`, protocol-relative instead of root-relative.
- Every other `BASE_URL` join uses the `base` const that strips the trailing slash; these two were the only ones that didn't. `team.astro` already declares that const and just wasn't using it.
- Affects 148 blog post pages plus `/team/`.
- Local link check with the repo's own config: 149 errors before, 0 after; `grep -r 'href="//' dist/` now comes back empty.

Link checking on `main` pushes fails separately for unrelated external link rot, covered in #184.